### PR TITLE
Add an interface for AuthConversation

### DIFF
--- a/authConversation.go
+++ b/authConversation.go
@@ -8,14 +8,18 @@ import (
 
 // AuthConversator is an interface for asking user for auth information.
 type AuthConversator interface {
-	// AskPhoneNumber asks user for phone number.
+	// AskPhoneNumber is called to ask user for phone number.
+	// phone number to login should be returned.
 	AskPhoneNumber() (string, error)
-	// AskPassword asks user for 2FA password.
-	AskPassword() (string, error)
-	// AskCode asks user for auth code.
+	// AskCode is called to ask user for OTP.
+	// OTP should be returned.
 	AskCode() (string, error)
-	// AskRetryCode asks user for retrying 2FA password.
+	// AskPassword is called to ask user for 2FA password.
+	// 2FA password should be returned.
+	AskPassword() (string, error)
+	// RetryPassword is called when the 2FA password is incorrect
 	// attemptsLeft is the number of attempts left.
+	// 2FA password should be returned.
 	RetryPassword(attemptsLeft int) (string, error)
 }
 

--- a/authConversation.go
+++ b/authConversation.go
@@ -1,0 +1,48 @@
+package gotgproto
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// AuthConversator is an interface for asking user for auth information.
+type AuthConversator interface {
+	// AskPhoneNumber asks user for phone number.
+	AskPhoneNumber() (string, error)
+	// AskPassword asks user for 2FA password.
+	AskPassword() (string, error)
+	// AskCode asks user for auth code.
+	AskCode() (string, error)
+	// AskRetryCode asks user for retrying 2FA password.
+	// attemptsLeft is the number of attempts left.
+	RetryPassword(attemptsLeft int) (string, error)
+}
+
+func BasicConversator() AuthConversator {
+	return &basicConservator{}
+}
+
+type basicConservator struct{}
+
+func (b *basicConservator) AskPhoneNumber() (string, error) {
+	fmt.Print("Enter Phone Number: ")
+	return bufio.NewReader(os.Stdin).ReadString('\n')
+}
+
+func (b *basicConservator) AskPassword() (string, error) {
+	fmt.Print("Enter 2FA password: ")
+	return bufio.NewReader(os.Stdin).ReadString('\n')
+}
+
+func (b *basicConservator) AskCode() (string, error) {
+	fmt.Print("Enter Code: ")
+	return bufio.NewReader(os.Stdin).ReadString('\n')
+}
+
+func (b *basicConservator) RetryPassword(trialsLeft int) (string, error) {
+	fmt.Println("The 2FA Code you just entered seems to be incorrect,")
+	fmt.Println("Attempts Left:", trialsLeft)
+	fmt.Println("Please try again.... ")
+	return b.AskCode()
+}

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const VERSION = "v1.0.0-beta14"
+const VERSION = "v1.0.0-beta15"
 
 type Client struct {
 	// Dispatcher handlers the incoming updates and execute mapped handlers. It is recommended to use dispatcher.MakeDispatcher function for this field.

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const VERSION = "v1.0.0-beta15"
+const VERSION = "v1.0.0-beta14"
 
 type Client struct {
 	// Dispatcher handlers the incoming updates and execute mapped handlers. It is recommended to use dispatcher.MakeDispatcher function for this field.

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9g
 github.com/glebarez/go-sqlite v1.21.2/go.mod h1:sfxdZyhQjTM2Wry3gVYWaW072Ri1WMdWJi0k6+3382k=
 github.com/glebarez/sqlite v1.10.0 h1:u4gt8y7OND/cCei/NMHmfbLxF6xP2wgKcT/BJf2pYkc=
 github.com/glebarez/sqlite v1.10.0/go.mod h1:IJ+lfSOmiekhQsFTJRx/lHtGYmCdtAiTaf5wI9u5uHA=
-github.com/go-faster/errors v0.7.0 h1:UnD/xusnfUgtEYkgRZohqL2AfmPTwv13NAJwwFFaNYc=
-github.com/go-faster/errors v0.7.0/go.mod h1:5ySTjWFiphBs07IKuiL69nxdfd5+fzh1u7FPGZP2quo=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
 github.com/go-faster/errors v0.7.1/go.mod h1:5ySTjWFiphBs07IKuiL69nxdfd5+fzh1u7FPGZP2quo=
 github.com/go-faster/jx v1.1.0 h1:ZsW3wD+snOdmTDy9eIVgQdjUpXRRV4rqW8NS3t+20bg=

--- a/userAuth.go
+++ b/userAuth.go
@@ -1,11 +1,8 @@
 package gotgproto
 
 import (
-	"bufio"
 	"context"
 	"errors"
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/gotd/td/telegram/auth"
@@ -25,7 +22,8 @@ func (noSignUp) AcceptTermsOfService(_ context.Context, tos tg.HelpTermsOfServic
 
 // termAuth implements authentication via terminal.
 type termAuth struct {
-	client *auth.Client
+	client      *auth.Client
+	conversator AuthConversator
 	noSignUp
 
 	phone string
@@ -35,26 +33,23 @@ func (a termAuth) Phone(_ context.Context) (string, error) {
 	if a.phone != "" {
 		return a.phone, nil
 	}
-	fmt.Print("Enter Phone Number: ")
-	phone, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	phone, err := a.conversator.AskPhoneNumber()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(phone), nil
 }
 
-func (termAuth) Password(_ context.Context) (string, error) {
-	fmt.Print("Enter 2FA password: ")
-	pass, err := bufio.NewReader(os.Stdin).ReadString('\n')
+func (a termAuth) Password(_ context.Context) (string, error) {
+	pass, err := a.conversator.AskPassword()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(pass), nil
 }
 
-func (termAuth) Code(_ context.Context, _ *tg.AuthSentCode) (string, error) {
-	fmt.Print("Enter Code: ")
-	code, err := bufio.NewReader(os.Stdin).ReadString('\n')
+func (a termAuth) Code(_ context.Context, _ *tg.AuthSentCode) (string, error) {
+	code, err := a.conversator.AskCode()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Ref: https://t.me/GoTGProtoChat/2342

This PR adds an interface for Auth Conversation so that conversation can remain generic as per the needs.
Library will use `gotgproto.basicConversator` as default conversator if nothing is provided through opts.
  It can be initiated via `gotgproto.BasicConversator()` function if one wants to pass it explicitly. 