### PR TITLE
Fixed ctx random seed to nanosecond to prevent the randomID generated…

### DIFF
--- a/ext/context.go
+++ b/ext/context.go
@@ -44,7 +44,7 @@ func NewContext(ctx context.Context, client *tg.Client, peerStorage *storage.Pee
 		Self:        self,
 		Sender:      sender,
 		Entities:    entities,
-		random:      rand.New(rand.NewSource(time.Now().Unix())),
+		random:      rand.New(rand.NewSource(time.Now().UnixNano())),
 		setReply:    setReply,
 		PeerStorage: peerStorage,
 	}


### PR DESCRIPTION
Fixed ctx random seed to nanosecond to prevent the randomID generated by receiving concurrent requests from being consistent. The message sent is always the same