### PR TITLE
Resolve Incorrect Update.userId Assignment

### DIFF
--- a/ext/update.go
+++ b/ext/update.go
@@ -43,6 +43,7 @@ func GetNewUpdate(ctx context.Context, client *tg.Client, selfUserId int64, p *s
 	case *tg.UpdateNewMessage:
 		m := update.GetMessage()
 		u.EffectiveMessage = types.ConstructMessage(m)
+		u.fillUserIdFromMessage(selfUserId)
 		diff, err := client.UpdatesGetDifference(ctx, &tg.UpdatesGetDifferenceRequest{
 			Pts:  update.Pts - 1,
 			Date: int(time.Now().Unix()),
@@ -70,7 +71,6 @@ func GetNewUpdate(ctx context.Context, client *tg.Client, selfUserId int64, p *s
 				}
 			}
 		}
-		u.fillUserIdFromMessage(selfUserId)
 	case message.AnswerableMessageUpdate:
 		m := update.GetMessage()
 		u.EffectiveMessage = types.ConstructMessage(m)


### PR DESCRIPTION
Referencing issue [#85](https://github.com/celestix/gotgproto/issues/85).

The problem arises because Go maps are unordered, and `getDifferent` is called before `fillUserIdFromMessage`. This sequence can lead to an incorrect `userId` being assigned to `Update.userId` due to inconsistent entity processing. Ensuring proper order of operations will resolve this.