### PR TITLE
feat(ext): DeleteMessages support private chats

### DIFF
--- a/ext/context.go
+++ b/ext/context.go
@@ -569,7 +569,7 @@ func (ctx *Context) DeleteMessages(chatId int64, messageIDs []int) error {
 		return mtp_errors.ErrPeerNotFound
 	}
 	switch storage.EntityType(peer.Type) {
-	case storage.TypeChat:
+	case storage.TypeChat, storage.TypeUser:
 		_, err := ctx.Raw.MessagesDeleteMessages(ctx, &tg.MessagesDeleteMessagesRequest{
 			Revoke: true,
 			ID:     messageIDs,
@@ -584,8 +584,6 @@ func (ctx *Context) DeleteMessages(chatId int64, messageIDs []int) error {
 			ID: messageIDs,
 		})
 		return err
-	case storage.TypeUser:
-		return mtp_errors.ErrNotChat
 	default:
 		return mtp_errors.ErrPeerNotFound
 	}
@@ -618,19 +616,19 @@ func (ctx *Context) ForwardMessages(fromChatId, toChatId int64, request *tg.Mess
 		request.RandomID[i] = ctx.generateRandomID()
 	}
 	return ctx.Raw.MessagesForwardMessages(ctx, &tg.MessagesForwardMessagesRequest{
-		RandomID: request.RandomID,
-		ID:       request.ID,
-		FromPeer: fromPeer,
-		ToPeer:   toPeer,
-		DropAuthor: request.DropAuthor,
-		Silent:     request.Silent,
-		Background: request.Background,
-		WithMyScore: request.WithMyScore,
-		DropMediaCaptions: request.DropMediaCaptions,
-		Noforwards: request.Noforwards,
-		TopMsgID: request.TopMsgID,
-		ScheduleDate: request.ScheduleDate,
-		SendAs: request.SendAs,
+		RandomID:           request.RandomID,
+		ID:                 request.ID,
+		FromPeer:           fromPeer,
+		ToPeer:             toPeer,
+		DropAuthor:         request.DropAuthor,
+		Silent:             request.Silent,
+		Background:         request.Background,
+		WithMyScore:        request.WithMyScore,
+		DropMediaCaptions:  request.DropMediaCaptions,
+		Noforwards:         request.Noforwards,
+		TopMsgID:           request.TopMsgID,
+		ScheduleDate:       request.ScheduleDate,
+		SendAs:             request.SendAs,
 		QuickReplyShortcut: request.QuickReplyShortcut,
 	})
 }


### PR DESCRIPTION
**Private Chats Support for DeleteMessages**
The DeleteMessages helper method is slightly modified to support private chats (storage.TypeUser). The raw method for private and regular group chats is the same.