### PR TITLE
fix: skip saving when peer channel or user is min

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -207,7 +207,7 @@ func (dp *NativeDispatcher) handleUpdateRepliedToMessage(u *ext.Update, ctx cont
 func saveUsersPeers(u tg.UserClassArray, p *storage.PeerStorage) {
 	for _, user := range u {
 		c, ok := user.AsNotEmpty()
-		if !ok {
+		if !ok || c.Min {
 			continue
 		}
 		p.AddPeer(c.ID, c.AccessHash, storage.TypeUser, c.Username)
@@ -217,7 +217,7 @@ func saveUsersPeers(u tg.UserClassArray, p *storage.PeerStorage) {
 func saveChatsPeers(u tg.ChatClassArray, p *storage.PeerStorage) {
 	for _, chat := range u {
 		channel, ok := chat.(*tg.Channel)
-		if ok {
+		if ok && !channel.Min {
 			p.AddPeer(channel.ID, channel.AccessHash, storage.TypeChannel, channel.Username)
 			continue
 		}


### PR DESCRIPTION
#119 

I noticed we’re storing both [min](https://core.telegram.org/api/min) `AccessHash` and regular `AccessHash` in the same database. In some channels—especially larger ones—the min `AccessHash` always overwrites the regular one, and using a min AccessHash out of context triggers  `CHANNEL_INVALID`. Given the current design,  I’ve made a few simple changes to skip saving the AccessHash when it’s a `min` in the update.

