### PR TITLE
fix: handle min channel and user in GetNewUpdate

### DIFF
--- a/ext/update.go
+++ b/ext/update.go
@@ -60,7 +60,7 @@ func GetNewUpdate(ctx context.Context, client *tg.Client, selfUserId int64, p *s
 						p.AddPeer(chat.ID, storage.DefaultAccessHash, storage.TypeChat, storage.DefaultUsername)
 					case *tg.Channel:
 						e.Channels[chat.ID] = chat
-						if p.GetPeerById(chat.ID) != nil {
+						if chat.Min || p.GetPeerById(chat.ID) != nil {
 							continue
 						}
 						p.AddPeer(chat.ID, chat.AccessHash, storage.TypeChannel, chat.Username)
@@ -72,7 +72,7 @@ func GetNewUpdate(ctx context.Context, client *tg.Client, selfUserId int64, p *s
 						continue
 					}
 					e.Users[user.ID] = user
-					if p.GetPeerById(user.ID) != nil {
+					if user.Min || p.GetPeerById(user.ID) != nil {
 						continue
 					}
 					p.AddPeer(user.ID, user.AccessHash, storage.TypeUser, user.Username)


### PR DESCRIPTION
The previous pr https://github.com/celestix/gotgproto/pull/124 does not seem to have completely fixed this problem. We still need to handle the Min AccessHash in `GetNewUpdate`.